### PR TITLE
Exclude the `templates` directory from the released gem.

### DIFF
--- a/cloudflare-turnstile-rails.gemspec
+++ b/cloudflare-turnstile-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ templates/ .git .github appveyor Gemfile])
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
The `templates` directory is used only for development and generator scaffolding. It should not be part of the final gem artifact.