### PR TITLE
Stop raising exception for missing Turnstile response.

### DIFF
--- a/lib/cloudflare/turnstile/rails/verification.rb
+++ b/lib/cloudflare/turnstile/rails/verification.rb
@@ -47,11 +47,7 @@ module Cloudflare
 
       module Verification
         def self.verify(response: nil, secret: nil, remoteip: nil, idempotency_key: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-          if response.nil? || response.strip.empty?
-            unless ::Rails.env.test? && Rails.configuration.auto_populate_response_in_test_env
-              raise ConfigurationError, ErrorMessage.for(ErrorCode::MISSING_INPUT_RESPONSE)
-            end
-
+          if (response.nil? || response.strip.empty?) && ::Rails.env.test? && Rails.configuration.auto_populate_response_in_test_env # rubocop:disable Layout/LineLength
             response = 'dummy-response'
           end
 

--- a/test/cloudflare/turnstile/rails/verification_test.rb
+++ b/test/cloudflare/turnstile/rails/verification_test.rb
@@ -74,11 +74,13 @@ module Cloudflare
             )
         end
 
-        def test_missing_response_raises
-          expected = ErrorMessage.for(ErrorCode::MISSING_INPUT_RESPONSE)
+        def test_missing_response_proceeds_and_returns_verification_response
+          stub_verify('success' => true, 'error-codes' => [])
+          resp = Verification.verify(response: '')
 
-          err = assert_raises(ConfigurationError) { Verification.verify(response: '') }
-          assert_equal expected, err.message
+          assert_kind_of VerificationResponse, resp
+          assert_predicate resp, :success?
+          assert_empty resp.errors
         end
 
         def test_missing_secret_raises


### PR DESCRIPTION
Previously, a missing `response` triggered a `ConfigurationError`, which caused excessive noise in error trackers like Rollbar and Sentry. These logs were not actionable and stemmed largely from bot traffic. Now, the system returns a user-friendly message indicating the user's humanity could not be verified, avoiding unnecessary error reports.