### PR TITLE
Stop one bad Turnstile widget from breaking the rest

### DIFF
--- a/lib/cloudflare/turnstile/rails/assets/javascripts/cloudflare_turnstile_helper.js
+++ b/lib/cloudflare/turnstile/rails/assets/javascripts/cloudflare_turnstile_helper.js
@@ -13,8 +13,14 @@
         el = elements[i];
 
         if (!el.dataset.initialized && el.childElementCount === 0) {
-          turnstile.render(el);
-          el.dataset.initialized = 'true';
+          try {
+            turnstile.render(el);
+            el.dataset.initialized = 'true';
+          }
+          catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn('cloudflare-turnstile-rails: turnstile.render failed', e);
+          }
         }
       }
     }


### PR DESCRIPTION
If turnstile.render throws on a single widget (bad sitekey, network hiccup, browser extension), the loop bails and every later widget on the page fails to initialize too. Catch it per-widget and log a warning so the rest still render.