### PR TITLE
Narrow Rails runtime dependencies

### DIFF
--- a/cloudflare-turnstile-rails.gemspec
+++ b/cloudflare-turnstile-rails.gemspec
@@ -29,8 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'rails', '>= 5.0'
+  spec.add_dependency 'actionpack', '>= 5.0'
+  spec.add_dependency 'actionview', '>= 5.0'
+  spec.add_dependency 'railties', '>= 5.0'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Replace the broad rails meta-gem dependency with the Rails components this gem uses directly: actionpack for controller integration, actionview for helper rendering, and railties for the railtie, engine, and generator hooks. This avoids pulling unused Rails frameworks such as Active Record, Action Mailer, Active Job, Action Cable, Active Storage, Action Mailbox, and Action Text while preserving the supported Rails integration surface.

Closes #36