### PR TITLE
Guard assets initializer against apps with no asset pipeline.

### DIFF
--- a/lib/cloudflare/turnstile/rails/engine.rb
+++ b/lib/cloudflare/turnstile/rails/engine.rb
@@ -5,6 +5,8 @@ module Cloudflare
         engine_name 'cloudflare_turnstile_rails'
 
         initializer 'cloudflare_turnstile.assets' do |app|
+          next unless app.config.respond_to?(:assets)
+
           js_path = ::Cloudflare::Turnstile::Rails::Engine.root.join(
             'lib', 'cloudflare', 'turnstile', 'rails', 'assets', 'javascripts'
           )

--- a/test/cloudflare/turnstile/rails/engine_test.rb
+++ b/test/cloudflare/turnstile/rails/engine_test.rb
@@ -16,6 +16,13 @@ module Cloudflare
           @initializer = Engine.initializers.find { |i| i.name == 'cloudflare_turnstile.assets' }
         end
 
+        def test_initializer_does_not_raise_when_assets_not_configured
+          config_without_assets = Struct.new(:other).new(nil)
+          app_without_assets = Struct.new(:config).new(config_without_assets)
+
+          assert_silent { @initializer.run(app_without_assets) }
+        end
+
         def test_that_initializer_is_defined
           assert @initializer, "Expected an initializer named 'cloudflare_turnstile.assets'"
         end

--- a/test/cloudflare/turnstile/rails/engine_test.rb
+++ b/test/cloudflare/turnstile/rails/engine_test.rb
@@ -18,6 +18,7 @@ module Cloudflare
 
         def test_initializer_skips_when_assets_not_configured
           app = Struct.new(:config).new(Object.new)
+
           assert_nil @initializer.run(app)
         end
 

--- a/test/cloudflare/turnstile/rails/engine_test.rb
+++ b/test/cloudflare/turnstile/rails/engine_test.rb
@@ -16,11 +16,9 @@ module Cloudflare
           @initializer = Engine.initializers.find { |i| i.name == 'cloudflare_turnstile.assets' }
         end
 
-        def test_initializer_does_not_raise_when_assets_not_configured
-          config_without_assets = Struct.new(:other).new(nil)
-          app_without_assets = Struct.new(:config).new(config_without_assets)
-
-          assert_silent { @initializer.run(app_without_assets) }
+        def test_initializer_skips_when_assets_not_configured
+          app = Struct.new(:config).new(Object.new)
+          assert_nil @initializer.run(app)
         end
 
         def test_that_initializer_is_defined


### PR DESCRIPTION
Apps without Sprockets or Propshaft do not have `app.config.assets`, causing a `NoMethodError` when the engine initializer runs. Skip the block entirely when `config.assets` is not present.