### PR TITLE
Avoid broken i18n release that crashes CI on Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,11 @@ gemspec
 # A Ruby library for testing your library against different versions of dependencies
 gem 'appraisal'
 
+# i18n 1.15.0 uses the Fiber[] storage API (Ruby 3.2+) but declares support for
+# Ruby >= 3.1, so it installs and crashes on Ruby 3.1. Avoid it below 3.2.
+# i18n v1.15.1 declares Ruby correctly, so only v1.15.0 needs to be excluded
+gem 'i18n', '!= 1.15.0' if RUBY_VERSION < '3.2.0'
+
 group :development do
   gem 'rake'
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,6 @@ gemspec
 # A Ruby library for testing your library against different versions of dependencies
 gem 'appraisal'
 
-# i18n 1.15.0 uses the Fiber[] storage API (Ruby 3.2+) but declares support for
-# Ruby >= 3.1, so it installs and crashes on Ruby 3.1. Avoid it below 3.2.
-# i18n v1.15.1 declares Ruby correctly, so only v1.15.0 needs to be excluded
-gem 'i18n', '!= 1.15.0' if RUBY_VERSION < '3.2.0'
-
 group :development do
   gem 'rake'
 

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -16,6 +16,11 @@ append_to_file 'Gemfile', <<~RUBY
     gem 'benchmark'
   end
 
+  # i18n 1.15.0 uses the Fiber[] storage API (Ruby 3.2+) but declares support for
+  # Ruby >= 3.1, so it installs and crashes on Ruby 3.1. Avoid it below 3.2.
+  # i18n v1.15.1 declares Ruby correctly, so only v1.15.0 needs to be excluded
+  gem 'i18n', '!= 1.15.0' if RUBY_VERSION < '3.2.0'
+
   # Resolve the "uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)" issue
   gem 'concurrent-ruby', '< 1.3.5'
 


### PR DESCRIPTION
The i18n 1.15.0 release switched to the Fiber storage API that only exists in Ruby 3.2+, yet still advertises support for Ruby 3.1. That made the test suite install it on Ruby 3.1 and crash before any test ran. Skip that single release on Rubies below 3.2 so they fall back to a working version.