### PR TITLE
Ship only runtime files in the published gem

### DIFF
--- a/cloudflare-turnstile-rails.gemspec
+++ b/cloudflare-turnstile-rails.gemspec
@@ -18,11 +18,14 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  # Only runtime files (lib, license, readme) are shipped; development and tooling
+  # files are excluded to keep the published gem minimal.
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ templates/ .git .github appveyor Gemfile])
+        %w[.rubocop.yml Appraisals Rakefile eslint.config.js package.json].include?(f) ||
+        f.start_with?(*%w[bin/ test/ templates/ .git Gemfile])
     end
   end
   spec.bindir = 'exe'

--- a/cloudflare-turnstile-rails.gemspec
+++ b/cloudflare-turnstile-rails.gemspec
@@ -16,16 +16,14 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/releases"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  # Only runtime files (lib, license, readme) are shipped; development and tooling
-  # files are excluded to keep the published gem minimal.
-  gemspec = File.basename(__FILE__)
+  # Ship only what the gem needs at runtime: the library code (including its
+  # generators, assets, and locales) plus the license and readme. Using an
+  # allowlist keeps tests, tooling, CI config, and the sample app template out
+  # of the package even as new development files are added over time.
+  root_files = %w[LICENSE.txt README.md]
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        %w[.rubocop.yml Appraisals Rakefile eslint.config.js package.json].include?(f) ||
-        f.start_with?(*%w[bin/ test/ templates/ .git Gemfile])
+    ls.readlines("\x0", chomp: true).select do |f|
+      f.start_with?('lib/') || root_files.include?(f)
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
Drop stale exclusion entries for paths that no longer exist and explicitly skip development and tooling files, so the released gem contains just the code, license, and readme it needs to run.