### PR TITLE
Add single status checks to summarize CI matrices

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,15 @@ jobs:
 
       - name: Run linters
         run: bin/lint --no-fix
+
+  # Single stable status check that summarises the job above, so branch
+  # protection can require one name ("Lint") that never changes.
+  lint-result:
+    name: Lint
+    if: always()
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any lint job did not succeed
+        if: needs.lint.result != 'success'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,15 @@ jobs:
           name: system-test-screenshots-${{ matrix.ruby }}-${{ matrix.browser }}
           path: /tmp/screenshots
           if-no-files-found: ignore
+
+  # Single stable status check that summarises the whole matrix above, so
+  # branch protection can require one name ("Test") instead of every cell.
+  test-result:
+    name: Test
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any matrix job did not succeed
+        if: needs.test.result != 'success'
+        run: exit 1


### PR DESCRIPTION
The test workflow fans out into many Ruby and browser jobs, so branch protection had to list every combination by hand and broke whenever the matrix changed. Each workflow now ends with one aggregate job that passes only if everything else passed, giving a stable check name to require.