### PR TITLE
Allow setting default widget options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,35 @@ Supports **Rails 5.0 → latest** and **Ruby 2.6 → latest**, with the full Rai
    <%= cloudflare_turnstile_tag %>
    ```
 
-  That's it! Though it is recommended to match your `theme` and `language` to your app's design and locale:
+  That's it! By default the widget auto-detects the visitor's `theme` and `language`.
+
+* To match your app's design and locale, set defaults once in the initializer and they'll apply to every `cloudflare_turnstile_tag` automatically:
+
+  ```ruby
+  Cloudflare::Turnstile::Rails.configure do |config|
+    config.default_data = {
+      theme: 'light',
+      language: 'en'
+    }
+  end
+  ```
+
+  Values may also be a proc, evaluated at render time — useful for following the current locale:
+
+  ```ruby
+  config.default_data = { language: -> { I18n.locale } }
+  ```
+
+* You can still override any default (or add extra options) on an individual tag via the `data:` option. Per-tag values take precedence over the configured defaults:
 
    ```erb
-   <%= cloudflare_turnstile_tag data: { theme: 'light', language: 'en' } %>
+   <%= cloudflare_turnstile_tag data: { theme: 'dark' } %>
+   ```
+
+* To drop a configured default on a single tag (so its attribute isn't rendered at all), pass `nil` for that key:
+
+   ```erb
+   <%= cloudflare_turnstile_tag data: { theme: nil } %>
    ```
 
 * For all available **data-**\* options (e.g., `action`, `cdata`, `theme`, etc.), refer to the official Cloudflare client-side rendering docs:

--- a/lib/cloudflare/turnstile/rails/configuration.rb
+++ b/lib/cloudflare/turnstile/rails/configuration.rb
@@ -3,7 +3,7 @@ module Cloudflare
     module Rails
       class Configuration
         attr_writer :script_url
-        attr_accessor :site_key, :secret_key, :render, :onload, :auto_populate_response_in_test_env
+        attr_accessor :site_key, :secret_key, :render, :onload, :default_data, :auto_populate_response_in_test_env
 
         def initialize
           @script_url = Cloudflare::SCRIPT_URL
@@ -11,6 +11,7 @@ module Cloudflare
           @secret_key = nil
           @render = nil
           @onload = nil
+          @default_data = {}
           @auto_populate_response_in_test_env = true
         end
 

--- a/lib/cloudflare/turnstile/rails/helpers.rb
+++ b/lib/cloudflare/turnstile/rails/helpers.rb
@@ -7,7 +7,7 @@ module Cloudflare
         def cloudflare_turnstile_tag(site_key: nil, include_script: true, **html_options) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
           site_key ||= Rails.configuration.site_key
           html_options[:class] = Cloudflare::WIDGET_CLASS unless html_options.key?(:class)
-          html_options[:data] ||= {}
+          html_options[:data] = cloudflare_turnstile_default_data.merge(html_options[:data] || {})
           html_options[:data][:sitekey] ||= site_key
 
           script_tag = nil
@@ -26,6 +26,16 @@ module Cloudflare
 
           widget = content_tag(:div, '', html_options)
           safe_join([script_tag, widget].compact, "\n")
+        end
+
+        private
+
+        # Resolves the configured default data attributes, evaluating any
+        # callable values (e.g. a proc bound to I18n.locale) at render time.
+        def cloudflare_turnstile_default_data
+          (Rails.configuration.default_data || {}).transform_values do |value|
+            value.respond_to?(:call) ? value.call : value
+          end
         end
       end
     end

--- a/lib/generators/cloudflare_turnstile/templates/cloudflare_turnstile.rb
+++ b/lib/generators/cloudflare_turnstile/templates/cloudflare_turnstile.rb
@@ -16,6 +16,15 @@ Cloudflare::Turnstile::Rails.configure do |config|
   # config.render = 'explicit'
   # config.onload = 'onloadTurnstileCallback'
 
+  # Optional: Default data-* attributes applied to every `cloudflare_turnstile_tag`.
+  # These are merged into each widget and can be overridden per tag via the `data:` option.
+  # See https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configuration-options
+  # Values may be a proc, evaluated at render time (e.g. to follow the current locale).
+  # config.default_data = {
+  #   theme: 'auto',
+  #   language: -> { I18n.locale }
+  # }
+
   # In the Rails Test environment, automatically fill in a dummy response if none was provided.
   # This lets you keep existing controller tests without having to add
   # params["cf-turnstile-response"] manually in every test.

--- a/test/cloudflare/turnstile/rails/configuration_test.rb
+++ b/test/cloudflare/turnstile/rails/configuration_test.rb
@@ -57,6 +57,16 @@ module Cloudflare
           assert_equal Cloudflare::SCRIPT_URL, @config.script_url
         end
 
+        def test_default_data_defaults_to_empty_hash
+          assert_empty(@config.default_data)
+        end
+
+        def test_default_data_is_configurable
+          @config.default_data = { theme: 'dark' }
+
+          assert_equal({ theme: 'dark' }, @config.default_data)
+        end
+
         def test_auto_populate_response_in_test_env
           # Test that the auto_populate_response_in_test_env is set to true by default
           assert @config.auto_populate_response_in_test_env

--- a/test/cloudflare/turnstile/rails/helpers_test.rb
+++ b/test/cloudflare/turnstile/rails/helpers_test.rb
@@ -14,6 +14,7 @@ module Cloudflare
             c.site_key = 'SITEKEY'
             c.secret_key = 'SECRETKEY'
             c.script_url = 'https://example.com/api.js'
+            c.default_data = {}
           end
         end
 
@@ -78,6 +79,46 @@ module Cloudflare
           html = cloudflare_turnstile_tag(site_key: 'OVERRIDE')
 
           assert_match(/data-sitekey="OVERRIDE"/, html)
+        end
+
+        test 'configured default_data is applied to the widget' do
+          Rails.configuration.default_data = { theme: 'light', language: 'en' }
+
+          html = cloudflare_turnstile_tag
+
+          assert_match(/data-theme="light"/, html)
+          assert_match(/data-language="en"/, html)
+          assert_match(/data-sitekey="SITEKEY"/, html)
+        end
+
+        test 'per-tag data overrides configured default_data' do
+          Rails.configuration.default_data = { theme: 'light', language: 'en' }
+
+          html = cloudflare_turnstile_tag(data: { theme: 'dark' })
+
+          # overridden key wins
+          assert_match(/data-theme="dark"/, html)
+          # non-overridden default is preserved
+          assert_match(/data-language="en"/, html)
+        end
+
+        test 'callable default_data values are evaluated at render time' do
+          Rails.configuration.default_data = { language: -> { 'fr' } }
+
+          html = cloudflare_turnstile_tag
+
+          assert_match(/data-language="fr"/, html)
+        end
+
+        test 'passing nil for a default_data key drops the attribute for that tag' do
+          Rails.configuration.default_data = { theme: 'light', language: 'en' }
+
+          html = cloudflare_turnstile_tag(data: { theme: nil })
+
+          # nil value removes the attribute entirely rather than rendering data-theme=""
+          refute_match(/data-theme=/, html)
+          # other defaults remain untouched
+          assert_match(/data-language="en"/, html)
         end
 
         test 'script tag is only rendered once when called multiple times' do


### PR DESCRIPTION
Add a config.default_data hash so apps can define shared Turnstile widget attributes (theme, language, etc.) once instead of repeating them on every tag. Values are merged into each widget and can be overridden per tag, including passing nil to drop a default. Callable values are evaluated at render time so defaults can follow the locale.