### PR TITLE
Ignore built gem files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /coverage/
 /doc/
 /pkg/
+*.gem
 /spec/reports/
 /test/generators/tmp/
 /tmp/


### PR DESCRIPTION
Keep locally built .gem packages out of version control so they are not committed by accident.