### PR TITLE
Keep lint passing on newer RuboCop versions

### DIFF
--- a/lib/cloudflare/turnstile/rails/verification.rb
+++ b/lib/cloudflare/turnstile/rails/verification.rb
@@ -48,9 +48,7 @@ module Cloudflare
 
       module Verification
         def self.verify(response: nil, secret: nil, remoteip: nil, idempotency_key: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-          if (response.nil? || response.strip.empty?) && ::Rails.env.test? && Rails.configuration.auto_populate_response_in_test_env # rubocop:disable Layout/LineLength
-            response = 'dummy-response'
-          end
+          response = 'dummy-response' if auto_populate_test_response?(response)
 
           secret ||= Rails.configuration.secret_key
           if secret.nil? || secret.strip.empty?
@@ -89,6 +87,13 @@ module Cloudflare
 
           VerificationResponse.new(json)
         end
+
+        def self.auto_populate_test_response?(response)
+          (response.nil? || response.strip.empty?) &&
+            ::Rails.env.test? &&
+            Rails.configuration.auto_populate_response_in_test_env
+        end
+        private_class_method :auto_populate_test_response?
       end
     end
   end


### PR DESCRIPTION
Reword the test-environment response guard so it no longer relies on disabling a line-length check inline. Newer RuboCop releases flagged that construct and failed the lint pipeline even though it passed with the older version pinned locally.