### PR TITLE
Let controllers keep the Turnstile alert to one render

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ Supports **Rails 5.0 → latest** and **Ruby 2.6 → latest**, with the full Rai
   end
   ```
 
+* Pass `flash: :now` when the failure re-renders the form instead of redirecting. The message is then shown on that render only, rather than also appearing on the next request. Pass `flash: false` to set no message at all:
+
+  ```ruby
+  def create
+    if valid_turnstile?(flash: :now)
+      redirect_to dashboard_path, notice: 'Success!'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+  ```
+
 * You may also pass additional **siteverify** parameters (e.g., `secret`, `response`, `remoteip`, `idempotency_key`) supported by Cloudflare's API:
   [Cloudflare Server-Side Validation Parameters](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/#required-parameters)
 

--- a/lib/cloudflare/turnstile/rails/controller_methods.rb
+++ b/lib/cloudflare/turnstile/rails/controller_methods.rb
@@ -17,14 +17,25 @@ module Cloudflare
           result
         end
 
-        def valid_turnstile?(model: nil, **opts)
+        def valid_turnstile?(model: nil, flash: true, **opts)
           response = verify_turnstile(model: model, **opts)
           success = response.is_a?(VerificationResponse) && response.success?
-          flash[:alert] = ErrorMessage.default if !success && model.nil?
+          add_turnstile_flash_alert(flash) if !success && model.nil?
           success
         end
 
         alias turnstile_valid? valid_turnstile?
+
+        private
+
+        # true keeps the alert for the next request, :now limits it to the
+        # current render, false leaves the flash alone.
+        def add_turnstile_flash_alert(mode)
+          return unless mode
+
+          store = mode == :now ? flash.now : flash
+          store[:alert] = ErrorMessage.default
+        end
       end
     end
   end

--- a/test/cloudflare/turnstile/rails/controller_methods_test.rb
+++ b/test/cloudflare/turnstile/rails/controller_methods_test.rb
@@ -33,10 +33,16 @@ module Cloudflare
           end
         end
 
+        class FakeFlash < Hash
+          def now
+            @now ||= {}
+          end
+        end
+
         def setup
           @model = DummyModel.new
           @params = {}
-          @flash = {}
+          @flash = FakeFlash.new
           singleton_class.define_method(:params) { @params }
           singleton_class.define_method(:flash) { @flash }
         end
@@ -171,14 +177,64 @@ module Cloudflare
           end
         end
 
+        def test_valid_turnstile_flash_now_keeps_the_alert_out_of_the_next_request
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?(flash: :now)
+
+            assert_equal ErrorMessage.default, @flash.now[:alert]
+            assert_empty @flash
+          end
+        end
+
+        def test_valid_turnstile_flash_now_sets_nothing_on_success
+          fake = VerificationResponse.new({ 'success' => true })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?(flash: :now)
+
+            assert_empty @flash.now
+            assert_empty @flash
+          end
+        end
+
+        def test_valid_turnstile_flash_false_leaves_the_flash_alone
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            refute valid_turnstile?(flash: false)
+
+            assert_empty @flash
+            assert_empty @flash.now
+          end
+        end
+
+        def test_valid_turnstile_flash_option_is_not_sent_to_cloudflare
+          captured = {}
+          fake = VerificationResponse.new({ 'success' => true })
+
+          Verification.stub(:verify, lambda { |**opts|
+            captured.merge!(opts)
+            fake
+          }) do
+            valid_turnstile?(flash: :now, remoteip: '1.2.3.4')
+
+            assert_equal '1.2.3.4', captured[:remoteip]
+            refute_includes captured.keys, :flash
+          end
+        end
+
         def test_valid_turnstile_does_not_set_flash_when_model_provided
           fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
 
           Verification.stub(:verify, fake) do
             valid_turnstile?(model: @model)
+            valid_turnstile?(model: @model, flash: :now)
 
             assert_empty @flash
-            assert_equal [[:base, ErrorMessage.default]], @model.errors.added
+            assert_empty @flash.now
+            assert_equal [[:base, ErrorMessage.default]] * 2, @model.errors.added
           end
         end
 


### PR DESCRIPTION
The alert set automatically when no model is given survived into the next request, so a form that re-renders after a failed challenge showed the message twice. Callers can now ask for a message that lasts only for the current render, or for no message at all. The default behaviour is unchanged.

```ruby
if valid_turnstile?(flash: :now)
  redirect_to dashboard_path, notice: 'Success!'
else
  render :new, status: :unprocessable_entity
end
```
