### PR TITLE
Scope the Turnstile failure message to the current render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   safely without racing Cloudflare's own auto-render observer. v1.x users
   who never touched `config.render` get the new behaviour transparently;
   see the v1.x → v2.0 upgrade guide in the README for details.
+- **The automatic failure message is now `flash.now[:alert]`.** When no model
+  is passed and verification fails, `valid_turnstile?` used to set a flash that
+  also survived into the following request, so a re-rendered form showed the
+  message twice: once on the render and again on the next page the visitor
+  landed on. Apps that redirect after a failed check now need to set
+  `flash[:alert]` themselves.
 - The internal "rendered" marker on placeholder elements moved from
   `data-cf-rendered` (which looked like a Cloudflare-owned attribute) to
   `data-turnstile-rendered`.
@@ -111,6 +117,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Most apps need no changes — the lazy mode is on by default and works out
   of the box.
+- If you redirect after a failed `valid_turnstile?` check with no model, set
+  `flash[:alert]` yourself. The gem's automatic message is scoped to the
+  current render now, so it no longer survives a redirect.
 - If you were on v1.x with `config.render = 'explicit'` and called
   `turnstile.render(...)` from your own JavaScript, set
   `config.manual_render = true`. The gem loads `api.js` for you and renders

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ renders, and DOM mutations exactly as it does in lazy mode.
   end
   ```
 
-* When **no model is provided** and verification fails, `valid_turnstile?` automatically sets `flash[:alert]` with the error message. This is useful for redirect-based flows:
+* When **no model is provided** and verification fails, `valid_turnstile?` automatically sets `flash.now[:alert]` with the error message, so the failure is reported on the view you render next:
 
   ```ruby
   def create
@@ -287,10 +287,17 @@ renders, and DOM mutations exactly as it does in lazy mode.
       # Passed: no model needed
       redirect_to dashboard_path, notice: 'Success!'
     else
-      # Failed: flash[:alert] is automatically set
-      redirect_to contact_path
+      # Failed: flash.now[:alert] is automatically set
+      render :new, status: :unprocessable_entity
     end
   end
+  ```
+
+  Re-rendering is usually the better response, since a redirect discards whatever the visitor typed. If you do redirect after a failed check, set the message yourself, because `flash.now` does not survive a redirect:
+
+  ```ruby
+  flash[:alert] = Cloudflare::Turnstile::Rails::ErrorMessage.default
+  redirect_to contact_path
   ```
 
 * You may also pass additional **siteverify** parameters (e.g., `secret`, `response`, `remoteip`, `idempotency_key`) supported by Cloudflare's API:
@@ -537,6 +544,9 @@ v2.0 introduces lazy mounting and changes a handful of defaults. Here's what to 
 | New JS API | – | `window.cfTurnstile.{ensureLoaded, mount, mountAll, mountMode}` |
 | Placeholder `min-height` | None | Size-aware (`65px` / `120px`) reserved in lazy mode to prevent CLS |
 | New config | – | `lazy_mount`, `manual_render`, `reserve_space` |
+| Automatic failure message (no model) | `flash[:alert]`, also shown on the next request | `flash.now[:alert]`, shown on the current render only |
+
+If you redirect after a failed `valid_turnstile?` check with no model, set `flash[:alert]` yourself. Re-rendering the form needs no change.
 
 #### Decision matrix
 

--- a/lib/cloudflare/turnstile/rails/controller_methods.rb
+++ b/lib/cloudflare/turnstile/rails/controller_methods.rb
@@ -20,7 +20,7 @@ module Cloudflare
         def valid_turnstile?(model: nil, **opts)
           response = verify_turnstile(model: model, **opts)
           success = response.is_a?(VerificationResponse) && response.success?
-          flash[:alert] = ErrorMessage.default if !success && model.nil?
+          flash.now[:alert] = ErrorMessage.default if !success && model.nil?
           success
         end
 

--- a/templates/shared/app/controllers/contacts_controller.rb
+++ b/templates/shared/app/controllers/contacts_controller.rb
@@ -5,7 +5,7 @@ class ContactsController < ApplicationController
     if valid_turnstile?
       redirect_to root_url, notice: 'Message sent successfully.'
     else
-      redirect_to new_contact_url
+      render :new, status: :unprocessable_entity
     end
   end
 end

--- a/templates/shared/app/controllers/pages_controller.rb
+++ b/templates/shared/app/controllers/pages_controller.rb
@@ -14,8 +14,9 @@ class PagesController < ApplicationController
     if valid_turnstile?
       redirect_to lazy_demo_path, notice: 'Lazy demo verified.'
     else
-      # `valid_turnstile?` already populated flash[:alert] with the
-      # gem's default error message on failure; just redirect.
+      # The gem's automatic message is scoped to the current render, so a
+      # redirect has to carry its own.
+      flash[:alert] = Cloudflare::Turnstile::Rails::ErrorMessage.default
       redirect_to lazy_demo_path
     end
   end
@@ -29,6 +30,7 @@ class PagesController < ApplicationController
     if valid_turnstile?
       redirect_to modal_demo_path, notice: 'Modal demo verified.'
     else
+      flash[:alert] = Cloudflare::Turnstile::Rails::ErrorMessage.default
       redirect_to modal_demo_path
     end
   end

--- a/templates/shared/test/controllers/contacts_controller_test.rb
+++ b/templates/shared/test/controllers/contacts_controller_test.rb
@@ -26,11 +26,23 @@ class ContactsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Message sent successfully.', flash[:notice]
   end
 
-  test 'POST /contact with failing Turnstile → redirect with flash alert' do
+  test 'POST /contact with failing Turnstile → re-renders the form with the alert' do
     Cloudflare::Turnstile::Rails.configuration.secret_key = '2x0000000000000000000000000000000AA'
     post contact_url
 
-    assert_redirected_to new_contact_url
-    assert_equal Cloudflare::Turnstile::Rails::ErrorMessage.default, flash[:alert]
+    assert_response :unprocessable_entity
+    assert_select 'p#alert', text: Cloudflare::Turnstile::Rails::ErrorMessage.default
+  end
+
+  test 'a failed Turnstile alert is not repeated on the next page' do
+    Cloudflare::Turnstile::Rails.configuration.secret_key = '2x0000000000000000000000000000000AA'
+    post contact_url
+
+    assert_select 'p#alert', count: 1
+
+    get new_contact_url
+
+    assert_response :success
+    assert_select 'p#alert', count: 0
   end
 end

--- a/templates/shared/test/integration/turnstile_helper_test.rb
+++ b/templates/shared/test/integration/turnstile_helper_test.rb
@@ -118,7 +118,7 @@ class TurnstileHelperTest < ActionDispatch::IntegrationTest
 
     post contact_url
 
-    assert_redirected_to new_contact_url
-    assert_equal Cloudflare::Turnstile::Rails::ErrorMessage.default, flash[:alert]
+    assert_response :unprocessable_entity
+    assert_select 'p#alert', text: Cloudflare::Turnstile::Rails::ErrorMessage.default
   end
 end

--- a/test/cloudflare/turnstile/rails/controller_methods_test.rb
+++ b/test/cloudflare/turnstile/rails/controller_methods_test.rb
@@ -33,10 +33,18 @@ module Cloudflare
           end
         end
 
+        # Stands in for ActionDispatch::Flash::FlashHash, where `now` writes to
+        # the same request but is never carried over to the next one.
+        class FakeFlash < Hash
+          def now
+            @now ||= {}
+          end
+        end
+
         def setup
           @model = DummyModel.new
           @params = {}
-          @flash = {}
+          @flash = FakeFlash.new
           singleton_class.define_method(:params) { @params }
           singleton_class.define_method(:flash) { @flash }
         end
@@ -167,7 +175,17 @@ module Cloudflare
           Verification.stub(:verify, fake) do
             valid_turnstile?
 
-            assert_equal ErrorMessage.default, @flash[:alert]
+            assert_equal ErrorMessage.default, @flash.now[:alert]
+          end
+        end
+
+        def test_valid_turnstile_does_not_carry_the_alert_into_the_next_request
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?
+
+            assert_empty @flash
           end
         end
 
@@ -178,6 +196,7 @@ module Cloudflare
             valid_turnstile?(model: @model)
 
             assert_empty @flash
+            assert_empty @flash.now
             assert_equal [[:base, ErrorMessage.default]], @model.errors.added
           end
         end
@@ -189,6 +208,7 @@ module Cloudflare
             valid_turnstile?
 
             assert_empty @flash
+            assert_empty @flash.now
           end
         end
 
@@ -199,6 +219,7 @@ module Cloudflare
             verify_turnstile
 
             assert_empty @flash
+            assert_empty @flash.now
           end
         end
       end


### PR DESCRIPTION
When verification fails and no model is given, `valid_turnstile?` now sets its message with `flash.now` instead of `flash`, so the message belongs to the render that reports the failure rather than also appearing on the next page the visitor loads.

The reason to prefer `flash.now` is that it is the composable of the two. A controller that redirects can promote the message with a single `flash[:alert] = ...` line. A controller that re-renders its form had no way to opt out of a persistent flash, so it had to skip `valid_turnstile?` entirely and set its own message from `verify_turnstile`, which is what devise-cloudflare-turnstile does today. This change lets a re-rendering controller call `valid_turnstile?` directly.

Callers that redirect after a failed check with no model now have to set the message themselves. The demo app that the template tests generate did exactly that, so the contact form switched to re-rendering the form and the lazy and modal demos keep their redirect and carry their own message, leaving both patterns covered. The README records the new behaviour in the v1.x to v2.0 upgrade guide.
