### PR TITLE
Let callers scope the Turnstile failure message to one render

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,22 @@ Supports **Rails 5.0 → latest** and **Ruby 2.6 → latest**, with the full Rai
   end
   ```
 
+  The automatic message is a regular flash, so it survives exactly one redirect. If you **re-render the form** instead of redirecting, pass `flash: :now` to scope the message to that render, so it doesn't also appear on the next page the visitor opens:
+
+  ```ruby
+  def create
+    if valid_turnstile?(flash: :now)
+      # Passed: no message is set either way
+      redirect_to dashboard_path, notice: 'Success!'
+    else
+      # Failed: flash.now[:alert] is automatically set
+      render :new, status: :unprocessable_entity
+    end
+  end
+  ```
+
+  Passing a `model` is the other option for a re-rendered form: the failure goes to `model.errors` and no flash is set at all.
+
 * You may also pass additional **siteverify** parameters (e.g., `secret`, `response`, `remoteip`, `idempotency_key`) supported by Cloudflare's API:
   [Cloudflare Server-Side Validation Parameters](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/#required-parameters)
 

--- a/lib/cloudflare/turnstile/rails/controller_methods.rb
+++ b/lib/cloudflare/turnstile/rails/controller_methods.rb
@@ -17,10 +17,18 @@ module Cloudflare
           result
         end
 
-        def valid_turnstile?(model: nil, **opts)
+        # flash: :keep carries the automatic failure message into the next request,
+        # for a redirect. flash: :now scopes it to the response being rendered. The
+        # keyword shadows the controller's own flash method, hence request.flash.
+        def valid_turnstile?(model: nil, flash: :keep, **opts)
           response = verify_turnstile(model: model, **opts)
           success = response.is_a?(VerificationResponse) && response.success?
-          flash[:alert] = ErrorMessage.default if !success && model.nil?
+
+          if !success && model.nil?
+            store = flash == :now ? request.flash.now : request.flash
+            store[:alert] = ErrorMessage.default
+          end
+
           success
         end
 

--- a/test/cloudflare/turnstile/rails/controller_methods_test.rb
+++ b/test/cloudflare/turnstile/rails/controller_methods_test.rb
@@ -33,17 +33,19 @@ module Cloudflare
           end
         end
 
+        FakeRequest = Struct.new(:flash)
+
         def setup
           @model = DummyModel.new
           @params = {}
-          @flash = {}
+          @flash = ActionDispatch::Flash::FlashHash.new
           singleton_class.define_method(:params) { @params }
-          singleton_class.define_method(:flash) { @flash }
+          singleton_class.define_method(:request) { FakeRequest.new(@flash) }
         end
 
         def teardown
           singleton_class.send(:remove_method, :params)
-          singleton_class.send(:remove_method, :flash)
+          singleton_class.send(:remove_method, :request)
         end
 
         def test_missing_response_adds_default_error
@@ -171,11 +173,68 @@ module Cloudflare
           end
         end
 
+        def test_valid_turnstile_alert_survives_into_the_next_request_by_default
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?
+            @flash.sweep
+
+            assert_equal ErrorMessage.default, @flash[:alert]
+          end
+        end
+
+        def test_valid_turnstile_with_flash_now_still_shows_the_alert_on_this_request
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?(flash: :now)
+
+            assert_equal ErrorMessage.default, @flash[:alert]
+          end
+        end
+
+        def test_valid_turnstile_with_flash_now_drops_the_alert_before_the_next_request
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?(flash: :now)
+            @flash.sweep
+
+            assert_nil @flash[:alert]
+          end
+        end
+
+        def test_valid_turnstile_flash_option_is_not_sent_to_cloudflare
+          captured = {}
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, lambda { |**opts|
+            captured.merge!(opts)
+            fake
+          }) do
+            valid_turnstile?(flash: :now)
+
+            refute_includes captured.keys, :flash
+          end
+        end
+
         def test_valid_turnstile_does_not_set_flash_when_model_provided
           fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
 
           Verification.stub(:verify, fake) do
             valid_turnstile?(model: @model)
+
+            assert_empty @flash
+            assert_equal [[:base, ErrorMessage.default]], @model.errors.added
+          end
+        end
+
+        def test_valid_turnstile_with_flash_now_and_a_model_still_reports_on_the_model_only
+          fake = VerificationResponse.new({ 'success' => false, 'error-codes' => [ErrorCode::INVALID_INPUT_RESPONSE] })
+
+          Verification.stub(:verify, fake) do
+            valid_turnstile?(model: @model, flash: :now)
 
             assert_empty @flash
             assert_equal [[:base, ErrorMessage.default]], @model.errors.added


### PR DESCRIPTION
When no model is passed, a failed check reports through a regular flash, which suits a redirect but also shows the message on the next page when the form is re-rendered instead. Callers can now pass flash: :now to limit it to the response being rendered. The default is unchanged.